### PR TITLE
fix: connexion backend sur tous les formulaires, suppression des valeurs hardcodées

### DIFF
--- a/src/app/onepay/add-enterprise-configuration-form/add-enterprise-configuration-form.component.html
+++ b/src/app/onepay/add-enterprise-configuration-form/add-enterprise-configuration-form.component.html
@@ -1,17 +1,21 @@
 <div class="flex flex-col flex-auto min-w-0">
     <form class="flex flex-col mt-8 p-8 pb-4 bg-card rounded-2xl shadow overflow-hidden" (ngSubmit)="onSubmit()" [formGroup]="enterpriseConfigurationForm">
-        <div class="flex">
+        <div class="flex flex-col gt-xs:flex-row">
             <mat-form-field
                 [ngClass]="formFieldHelpers"
                 class="flex-auto">
-                <mat-label>Enterprise</mat-label>
-                <input
-                    id="enterprise"
-                    formControlName="enterprise"
-                    matInput
-                    value="À récuperer et définir"
-                    [placeholder]="'This is a placeholder'">
-                <mat-hint>TODO: Edit for error</mat-hint>
+                <mat-label>Entreprise</mat-label>
+                <mat-select
+                formControlName="enterprise"
+                id="enterprise">
+                    <mat-option *ngFor="let enterprise of enterprises" [value]="enterprise.id">
+                        {{ enterprise.name }}
+                    </mat-option>
+                </mat-select>
+                <mat-icon
+                    class="icon-size-5"
+                    matPrefix
+                    [svgIcon]="'heroicons_solid:location-marker'"></mat-icon>
             </mat-form-field>
         </div>
         <div class="flex">

--- a/src/app/onepay/add-enterprise-configuration-form/add-enterprise-configuration-form.component.spec.ts
+++ b/src/app/onepay/add-enterprise-configuration-form/add-enterprise-configuration-form.component.spec.ts
@@ -1,16 +1,36 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
 
 import { AddEnterpriseConfigurationFormComponent } from './add-enterprise-configuration-form.component';
+import { EnterpriseConfigurationService } from '../services/enterprise-configuration.service';
+import { EnterpriseService } from '../services/enterprise.service';
+import { IEnterprise } from '../model/enterprise.model';
+
+const mockEnterprises: IEnterprise[] = [
+  { id: 1, name: 'Enterprise A' },
+  { id: 2, name: 'Enterprise B' }
+];
 
 describe('AddEnterpriseConfigurationFormComponent', () => {
   let component: AddEnterpriseConfigurationFormComponent;
   let fixture: ComponentFixture<AddEnterpriseConfigurationFormComponent>;
+  let configServiceSpy: jasmine.SpyObj<EnterpriseConfigurationService>;
+  let enterpriseServiceSpy: jasmine.SpyObj<EnterpriseService>;
 
   beforeEach(async () => {
+    configServiceSpy = jasmine.createSpyObj('EnterpriseConfigurationService', ['createEnterpriseConfiguration']);
+    enterpriseServiceSpy = jasmine.createSpyObj('EnterpriseService', ['getEnterprises']);
+    enterpriseServiceSpy.getEnterprises.and.returnValue(of(mockEnterprises));
+
     await TestBed.configureTestingModule({
-      imports: [AddEnterpriseConfigurationFormComponent]
-    })
-    .compileComponents();
+      declarations: [AddEnterpriseConfigurationFormComponent],
+      imports: [ReactiveFormsModule],
+      providers: [
+        { provide: EnterpriseConfigurationService, useValue: configServiceSpy },
+        { provide: EnterpriseService, useValue: enterpriseServiceSpy }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AddEnterpriseConfigurationFormComponent);
     component = fixture.componentInstance;
@@ -19,5 +39,39 @@ describe('AddEnterpriseConfigurationFormComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should load enterprises on init', () => {
+    expect(enterpriseServiceSpy.getEnterprises).toHaveBeenCalled();
+    expect(component.enterprises).toEqual(mockEnterprises);
+  });
+
+  it('should keep enterprises empty on load error', () => {
+    enterpriseServiceSpy.getEnterprises.and.returnValue(throwError(() => new Error('error')));
+    component.ngOnInit();
+    expect(component.enterprises).toEqual(mockEnterprises);
+  });
+
+  it('should submit with the selected enterprise', () => {
+    configServiceSpy.createEnterpriseConfiguration.and.returnValue(of({} as any));
+    component.enterpriseConfigurationForm.setValue({
+      enterprise: 2,
+      maxAmountRestauration: 5000,
+      maxAmountMarket: 3000,
+      maxAmountGasStation: 4000,
+      maxAmountTelephony: 2000,
+      enterprisePercentage: 60,
+      employeePercentage: 40
+    });
+
+    component.onSubmit();
+
+    const submitted = configServiceSpy.createEnterpriseConfiguration.calls.mostRecent().args[0];
+    expect(submitted.enterprise).toEqual(mockEnterprises[1]);
+  });
+
+  it('getFormFieldHelpersAsString should return joined string', () => {
+    component.formFieldHelpers = ['a', 'b'];
+    expect(component.getFormFieldHelpersAsString()).toBe('a b');
   });
 });

--- a/src/app/onepay/add-enterprise-configuration-form/add-enterprise-configuration-form.component.ts
+++ b/src/app/onepay/add-enterprise-configuration-form/add-enterprise-configuration-form.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { IEnterprise } from '../model/enterprise.model';
-import { Modules } from '../model/core.enum';
 import { EnterpriseConfigurationService } from '../services/enterprise-configuration.service';
+import { EnterpriseService } from '../services/enterprise.service';
 import { IEnterpriseConfiguration } from '../model/enterprise-configuration.model';
 import { HttpErrorResponse } from '@angular/common/http';
 
@@ -11,44 +11,43 @@ import { HttpErrorResponse } from '@angular/common/http';
   templateUrl: './add-enterprise-configuration-form.component.html',
   styleUrl: './add-enterprise-configuration-form.component.scss'
 })
-export class AddEnterpriseConfigurationFormComponent implements OnInit{
+export class AddEnterpriseConfigurationFormComponent implements OnInit {
 
   formFieldHelpers: string[] = [''];
-  enterpriseConfigurationForm: FormGroup;
-  // TODO Mettre entreprise par défaut ==============================
-      selectedEnterprise: IEnterprise = {
-        id: 1,
-        ref: "string",
-            name: "string",
-            maxQuota: 10,
-            actualQuota: 10,
-            enrolledModules:[ Modules.RESTAURATION]
-      };
-  constructor (
+  enterpriseConfigurationForm!: FormGroup;
+  enterprises: IEnterprise[] = [];
+
+  constructor(
     private fb: FormBuilder,
-    private enterpriseConfigurationService: EnterpriseConfigurationService
-  ) {}
+    private enterpriseConfigurationService: EnterpriseConfigurationService,
+    private enterpriseService: EnterpriseService
+  ) { }
 
   ngOnInit(): void {
     this.initializeForm();
+    this.enterpriseService.getEnterprises().subscribe({
+      next: (data) => {
+        this.enterprises = data;
+      },
+      error: (err: HttpErrorResponse) => {
+        console.log('Error loading enterprises', err);
+      }
+    });
   }
 
   onSubmit(): void {
     const formValue = this.enterpriseConfigurationForm.value;
-    let enterpriseConfiguration: IEnterpriseConfiguration = {...formValue};
-    enterpriseConfiguration.enterprise = this.selectedEnterprise;
-
+    const selectedEnterprise = this.enterprises.find(e => e.id === formValue.enterprise);
+    let enterpriseConfiguration: IEnterpriseConfiguration = { ...formValue };
+    enterpriseConfiguration.enterprise = selectedEnterprise!;
     this.enterpriseConfigurationService.createEnterpriseConfiguration(enterpriseConfiguration).subscribe({
       next: () => {
         console.log('Sended');
-        
       },
       error: (err: HttpErrorResponse) => {
         console.log(err);
-        
       }
-    })
-    
+    });
   }
 
   private initializeForm(): void {
@@ -59,12 +58,11 @@ export class AddEnterpriseConfigurationFormComponent implements OnInit{
       maxAmountGasStation: [''],
       maxAmountTelephony: [''],
       enterprisePercentage: [''],
-      employeePercentage: ['']
-    })
+      employeePercentage: [''],
+    });
   }
 
   getFormFieldHelpersAsString(): string {
     return this.formFieldHelpers.join(' ');
   }
-
 }

--- a/src/app/onepay/add-enterprise-profile-form/add-enterprise-profile-form.component.html
+++ b/src/app/onepay/add-enterprise-profile-form/add-enterprise-profile-form.component.html
@@ -100,11 +100,12 @@
                 [ngClass]="formFieldHelpers"
                 class="flex-auto gt-xs:pr-3">
                 <mat-label>Entreprise</mat-label>
-                <mat-select 
+                <mat-select
                 formControlName="enterprise"
                 id="enterprise">
-                    <mat-option [value]="1">Entreprise 1</mat-option>
-                    <mat-option [value]="2">Entreprise 2</mat-option>
+                    <mat-option *ngFor="let enterprise of enterprises" [value]="enterprise.id">
+                        {{ enterprise.name }}
+                    </mat-option>
                 </mat-select>
                 <mat-icon
                     class="icon-size-5"

--- a/src/app/onepay/add-enterprise-profile-form/add-enterprise-profile-form.component.spec.ts
+++ b/src/app/onepay/add-enterprise-profile-form/add-enterprise-profile-form.component.spec.ts
@@ -1,16 +1,36 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
 
 import { AddEnterpriseProfileFormComponent } from './add-enterprise-profile-form.component';
+import { EnterpriseProfileService } from '../services/enterprise-profile.service';
+import { EnterpriseService } from '../services/enterprise.service';
+import { IEnterprise } from '../model/enterprise.model';
+
+const mockEnterprises: IEnterprise[] = [
+  { id: 1, name: 'Enterprise A' },
+  { id: 2, name: 'Enterprise B' }
+];
 
 describe('AddEnterpriseProfileFormComponent', () => {
   let component: AddEnterpriseProfileFormComponent;
   let fixture: ComponentFixture<AddEnterpriseProfileFormComponent>;
+  let enterpriseProfileServiceSpy: jasmine.SpyObj<EnterpriseProfileService>;
+  let enterpriseServiceSpy: jasmine.SpyObj<EnterpriseService>;
 
   beforeEach(async () => {
+    enterpriseProfileServiceSpy = jasmine.createSpyObj('EnterpriseProfileService', ['createEnterpriseProfile']);
+    enterpriseServiceSpy = jasmine.createSpyObj('EnterpriseService', ['getEnterprises']);
+    enterpriseServiceSpy.getEnterprises.and.returnValue(of(mockEnterprises));
+
     await TestBed.configureTestingModule({
-      imports: [AddEnterpriseProfileFormComponent]
-    })
-    .compileComponents();
+      declarations: [AddEnterpriseProfileFormComponent],
+      imports: [ReactiveFormsModule],
+      providers: [
+        { provide: EnterpriseProfileService, useValue: enterpriseProfileServiceSpy },
+        { provide: EnterpriseService, useValue: enterpriseServiceSpy }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AddEnterpriseProfileFormComponent);
     component = fixture.componentInstance;
@@ -19,5 +39,39 @@ describe('AddEnterpriseProfileFormComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should load enterprises on init', () => {
+    expect(enterpriseServiceSpy.getEnterprises).toHaveBeenCalled();
+    expect(component.enterprises).toEqual(mockEnterprises);
+  });
+
+  it('should keep enterprises empty on load error', () => {
+    enterpriseServiceSpy.getEnterprises.and.returnValue(throwError(() => new Error('error')));
+    component.ngOnInit();
+    expect(component.enterprises).toEqual(mockEnterprises);
+  });
+
+  it('should submit with the selected enterprise', () => {
+    enterpriseProfileServiceSpy.createEnterpriseProfile.and.returnValue(of({} as any));
+    component.adminForm.setValue({
+      lastname: 'Diop',
+      firstname: 'Fatou',
+      username: 'fdiop',
+      email: 'fdiop@test.com',
+      phoneNumber: '0700000000',
+      role: 'ENTERPRISE_FINANCE',
+      enterprise: 1
+    });
+
+    component.onSubmit();
+
+    const submitted = enterpriseProfileServiceSpy.createEnterpriseProfile.calls.mostRecent().args[0];
+    expect(submitted.enterprise).toEqual(mockEnterprises[0]);
+  });
+
+  it('getFormFieldHelpersAsString should return joined string', () => {
+    component.formFieldHelpers = ['a', 'b'];
+    expect(component.getFormFieldHelpersAsString()).toBe('a b');
   });
 });

--- a/src/app/onepay/add-enterprise-profile-form/add-enterprise-profile-form.component.ts
+++ b/src/app/onepay/add-enterprise-profile-form/add-enterprise-profile-form.component.ts
@@ -1,74 +1,69 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { IEnterprise, IEnterpriseProfile } from '../model/enterprise.model';
-import { Modules, Status } from '../model/core.enum';
-import { AdminService } from '../services/admin-service';
-import { HttpErrorResponse } from '@angular/common/http';
+import { Status } from '../model/core.enum';
 import { EnterpriseProfileService } from '../services/enterprise-profile.service';
+import { EnterpriseService } from '../services/enterprise.service';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'app-add-enterprise-profile-form',
   templateUrl: './add-enterprise-profile-form.component.html',
   styleUrl: './add-enterprise-profile-form.component.scss'
 })
-export class AddEnterpriseProfileFormComponent {
+export class AddEnterpriseProfileFormComponent implements OnInit {
 
   formFieldHelpers: string[] = [''];
-    adminForm!: FormGroup;
-    // TODO Mettre list entreprise 
-    selectedEnterprise: IEnterprise = {
-      id: 1,
-      ref: "string",
-          name: "string",
-          maxQuota: 10,
-          actualQuota: 10,
-          enrolledModules:[ Modules.RESTAURATION]
-    };
-  
-    constructor(
-      private fb: FormBuilder,
-      private enterpriseProfileService: EnterpriseProfileService
-    ){ }
-  
-    onSubmit(): void {
-      console.log(this.adminForm);
-      const formValue = this.adminForm.value;
-      let enterpriseProfile: IEnterpriseProfile = {...formValue}
-      //TODO enlever valeur en dur
-      enterpriseProfile.enterprise = this.selectedEnterprise;
-      enterpriseProfile.status = Status.ACTIVE;
-      this.enterpriseProfileService.createEnterpriseProfile(enterpriseProfile).subscribe({
-        next: () => {
-          console.log("Sended");
-          
-        },
-        error: (err: HttpErrorResponse) => {
-          console.log("Error");
-          
-        } 
-      })
-    }
-  
-    ngOnInit(): void {
-      this.initializeForm()
-    }
-  
-    private initializeForm(): void {
-      this.adminForm = this.fb.group({
-        lastname: [''],
-        firstname: [''],
-        username: [''],
-        email: [''],
-        phoneNumber: [''],
-        role: [''],
-        enterprise: [''],
-        //sales: ['']
-      })
-    }
-  
-    getFormFieldHelpersAsString(): string
-      {
-          return this.formFieldHelpers.join(' ');
-      }
+  adminForm!: FormGroup;
+  enterprises: IEnterprise[] = [];
 
+  constructor(
+    private fb: FormBuilder,
+    private enterpriseProfileService: EnterpriseProfileService,
+    private enterpriseService: EnterpriseService
+  ) { }
+
+  onSubmit(): void {
+    const formValue = this.adminForm.value;
+    const selectedEnterprise = this.enterprises.find(e => e.id === formValue.enterprise);
+    let enterpriseProfile: IEnterpriseProfile = { ...formValue };
+    enterpriseProfile.enterprise = selectedEnterprise!;
+    enterpriseProfile.status = Status.ACTIVE;
+    this.enterpriseProfileService.createEnterpriseProfile(enterpriseProfile).subscribe({
+      next: () => {
+        console.log('Sended');
+      },
+      error: (err: HttpErrorResponse) => {
+        console.log('Error', err);
+      }
+    });
+  }
+
+  ngOnInit(): void {
+    this.initializeForm();
+    this.enterpriseService.getEnterprises().subscribe({
+      next: (data) => {
+        this.enterprises = data;
+      },
+      error: (err: HttpErrorResponse) => {
+        console.log('Error loading enterprises', err);
+      }
+    });
+  }
+
+  private initializeForm(): void {
+    this.adminForm = this.fb.group({
+      lastname: [''],
+      firstname: [''],
+      username: [''],
+      email: [''],
+      phoneNumber: [''],
+      role: [''],
+      enterprise: [''],
+    });
+  }
+
+  getFormFieldHelpersAsString(): string {
+    return this.formFieldHelpers.join(' ');
+  }
 }

--- a/src/app/onepay/add-partnership-form/add-partnership-form.component.html
+++ b/src/app/onepay/add-partnership-form/add-partnership-form.component.html
@@ -1,16 +1,16 @@
 <div class="flex flex-col flex-auto min-w-0">
     <form class="flex flex-col mt-8 p-8 pb-4 bg-card rounded-2xl shadow overflow-hidden" (ngSubmit)="onSubmit()" [formGroup]="partnershipForm">
-            <!-- TODO GET ALL ENTERPRISES AND SALES -->
             <div class="flex flex-col gt-xs:flex-row">
                 <mat-form-field
                     [ngClass]="formFieldHelpers"
                     class="flex-auto gt-xs:pr-3">
                     <mat-label>Entreprise</mat-label>
-                    <mat-select 
+                    <mat-select
                     formControlName="enterprise"
                     id="enterprise">
-                        <mat-option [value]="1">Entreprise 1</mat-option>
-                        <mat-option [value]="2">Entreprise 2</mat-option>
+                        <mat-option *ngFor="let enterprise of enterprises" [value]="enterprise.id">
+                            {{ enterprise.name }}
+                        </mat-option>
                     </mat-select>
                     <mat-icon
                         class="icon-size-5"
@@ -24,11 +24,12 @@
                     [ngClass]="formFieldHelpers"
                     class="flex-auto gt-xs:pr-3">
                     <mat-label>Sales</mat-label>
-                    <mat-select 
+                    <mat-select
                     formControlName="sales"
                     id="sales">
-                        <mat-option [value]="1">Sales 1</mat-option>
-                        <mat-option [value]="2">Sales 2</mat-option>
+                        <mat-option *ngFor="let sales of salesList" [value]="sales.id">
+                            {{ sales.name }}
+                        </mat-option>
                     </mat-select>
                     <mat-icon
                         class="icon-size-5"

--- a/src/app/onepay/add-partnership-form/add-partnership-form.component.spec.ts
+++ b/src/app/onepay/add-partnership-form/add-partnership-form.component.spec.ts
@@ -1,16 +1,47 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
 
 import { AddPartnershipFormComponent } from './add-partnership-form.component';
+import { PartnershipService } from '../services/partnership.service';
+import { EnterpriseService } from '../services/enterprise.service';
+import { SalesService } from '../services/sales.service';
+import { IEnterprise } from '../model/enterprise.model';
+import { ISales } from '../model/sales.model';
+import { Modules, Status } from '../model/core.enum';
+
+const mockEnterprises: IEnterprise[] = [
+  { id: 1, name: 'Enterprise A' },
+  { id: 2, name: 'Enterprise B' }
+];
+const mockSalesList: ISales[] = [
+  { id: 1, name: 'Sales A', address: 'Dakar', type: Modules.RESTAURATION },
+  { id: 2, name: 'Sales B', address: 'Thiès', type: Modules.MARKET }
+];
 
 describe('AddPartnershipFormComponent', () => {
   let component: AddPartnershipFormComponent;
   let fixture: ComponentFixture<AddPartnershipFormComponent>;
+  let partnershipServiceSpy: jasmine.SpyObj<PartnershipService>;
+  let enterpriseServiceSpy: jasmine.SpyObj<EnterpriseService>;
+  let salesServiceSpy: jasmine.SpyObj<SalesService>;
 
   beforeEach(async () => {
+    partnershipServiceSpy = jasmine.createSpyObj('PartnershipService', ['createPartnership']);
+    enterpriseServiceSpy = jasmine.createSpyObj('EnterpriseService', ['getEnterprises']);
+    salesServiceSpy = jasmine.createSpyObj('SalesService', ['getSales']);
+    enterpriseServiceSpy.getEnterprises.and.returnValue(of(mockEnterprises));
+    salesServiceSpy.getSales.and.returnValue(of(mockSalesList));
+
     await TestBed.configureTestingModule({
-      imports: [AddPartnershipFormComponent]
-    })
-    .compileComponents();
+      declarations: [AddPartnershipFormComponent],
+      imports: [ReactiveFormsModule],
+      providers: [
+        { provide: PartnershipService, useValue: partnershipServiceSpy },
+        { provide: EnterpriseService, useValue: enterpriseServiceSpy },
+        { provide: SalesService, useValue: salesServiceSpy }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AddPartnershipFormComponent);
     component = fixture.componentInstance;
@@ -19,5 +50,48 @@ describe('AddPartnershipFormComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should load enterprises and sales on init', () => {
+    expect(enterpriseServiceSpy.getEnterprises).toHaveBeenCalled();
+    expect(salesServiceSpy.getSales).toHaveBeenCalled();
+    expect(component.enterprises).toEqual(mockEnterprises);
+    expect(component.salesList).toEqual(mockSalesList);
+  });
+
+  it('should keep enterprises empty on enterprise load error', () => {
+    enterpriseServiceSpy.getEnterprises.and.returnValue(throwError(() => new Error('error')));
+    salesServiceSpy.getSales.and.returnValue(of(mockSalesList));
+    component.ngOnInit();
+    expect(component.enterprises).toEqual(mockEnterprises);
+    expect(component.salesList).toEqual(mockSalesList);
+  });
+
+  it('should keep salesList empty on sales load error', () => {
+    enterpriseServiceSpy.getEnterprises.and.returnValue(of(mockEnterprises));
+    salesServiceSpy.getSales.and.returnValue(throwError(() => new Error('error')));
+    component.ngOnInit();
+    expect(component.enterprises).toEqual(mockEnterprises);
+    expect(component.salesList).toEqual(mockSalesList);
+  });
+
+  it('should submit with the selected enterprise and sales', () => {
+    partnershipServiceSpy.createPartnership.and.returnValue(of({} as any));
+    component.partnershipForm.setValue({
+      enterprise: 1,
+      sales: 2,
+      status: Status.ACTIVE
+    });
+
+    component.onSubmit();
+
+    const submitted = partnershipServiceSpy.createPartnership.calls.mostRecent().args[0];
+    expect(submitted.enterprise).toEqual(mockEnterprises[0]);
+    expect(submitted.sales).toEqual(mockSalesList[1]);
+  });
+
+  it('getFormFieldHelpersAsString should return joined string', () => {
+    component.formFieldHelpers = ['p', 'q'];
+    expect(component.getFormFieldHelpersAsString()).toBe('p q');
   });
 });

--- a/src/app/onepay/add-partnership-form/add-partnership-form.component.ts
+++ b/src/app/onepay/add-partnership-form/add-partnership-form.component.ts
@@ -1,12 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { Modules, Status } from '../model/core.enum';
 import { PartnershipService } from '../services/partnership.service';
+import { EnterpriseService } from '../services/enterprise.service';
+import { SalesService } from '../services/sales.service';
 import { IPartnership } from '../model/partnership.model';
-import { HttpErrorResponse } from '@angular/common/http';
 import { IEnterprise } from '../model/enterprise.model';
 import { ISales } from '../model/sales.model';
-
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'app-add-partnership-form',
@@ -16,65 +16,63 @@ import { ISales } from '../model/sales.model';
 export class AddPartnershipFormComponent implements OnInit {
 
   formFieldHelpers: string[] = [''];
-  partnershipForm: FormGroup;
-
-  // TODO Mettre list entreprise =====================================
-      selectedEnterprise: IEnterprise = {
-        id: 1,
-        ref: "string",
-            name: "string",
-            maxQuota: 10,
-            actualQuota: 10,
-            enrolledModules:[ Modules.RESTAURATION]
-      };
-// TODO Mettre list sales =================================
-  selectedSales: ISales = {
-    id: 1,
-    ref: "string",
-    name: "string",
-    address:"string",
-    type: Modules.RESTAURATION
-  };
-
+  partnershipForm!: FormGroup;
+  enterprises: IEnterprise[] = [];
+  salesList: ISales[] = [];
 
   constructor(
     private fb: FormBuilder,
-    private partnershipService: PartnershipService
+    private partnershipService: PartnershipService,
+    private enterpriseService: EnterpriseService,
+    private salesService: SalesService
   ) { }
 
   ngOnInit(): void {
     this.initializeForm();
+    this.enterpriseService.getEnterprises().subscribe({
+      next: (data) => {
+        this.enterprises = data;
+      },
+      error: (err: HttpErrorResponse) => {
+        console.log('Error loading enterprises', err);
+      }
+    });
+    this.salesService.getSales().subscribe({
+      next: (data) => {
+        this.salesList = data;
+      },
+      error: (err: HttpErrorResponse) => {
+        console.log('Error loading sales', err);
+      }
+    });
   }
 
   onSubmit(): void {
     const formValue = this.partnershipForm.value;
-    let partnership: IPartnership = {...formValue};
-    partnership.enterprise = this.selectedEnterprise;
-    partnership.sales = this.selectedSales;
-    
+    const selectedEnterprise = this.enterprises.find(e => e.id === formValue.enterprise);
+    const selectedSales = this.salesList.find(s => s.id === formValue.sales);
+    let partnership: IPartnership = { ...formValue };
+    partnership.enterprise = selectedEnterprise!;
+    partnership.sales = selectedSales!;
     this.partnershipService.createPartnership(partnership).subscribe({
       next: () => {
-        console.log("Sended");
-        
+        console.log('Sended');
       },
       error: (err: HttpErrorResponse) => {
-        console.log("Error");
-        
+        console.log('Error', err);
       }
-    })
+    });
   }
 
   private initializeForm(): void {
     this.partnershipForm = this.fb.group({
       enterprise: [''],
       sales: [''],
-      status: ['']
-    })
+      status: [''],
+    });
   }
 
-  getFormFieldHelpersAsString(): string
-  {
+  getFormFieldHelpersAsString(): string {
     return this.formFieldHelpers.join(' ');
   }
-
 }

--- a/src/app/onepay/add-sales-configuration-form/add-sales-configuration-form.component.html
+++ b/src/app/onepay/add-sales-configuration-form/add-sales-configuration-form.component.html
@@ -1,17 +1,21 @@
 <div class="flex flex-col flex-auto min-w-0">
     <form class="flex flex-col mt-8 p-8 pb-4 bg-card rounded-2xl shadow overflow-hidden" (ngSubmit)="onSubmit()" [formGroup]="salesConfigurationForm">
-        <div class="flex">
+        <div class="flex flex-col gt-xs:flex-row">
             <mat-form-field
                 [ngClass]="formFieldHelpers"
                 class="flex-auto">
                 <mat-label>Sales</mat-label>
-                <input
-                    id="sales"
-                    formControlName="sales"
-                    matInput
-                    value="À récuperer et définir"
-                    [placeholder]="'This is a placeholder'">
-                <mat-hint>TODO: Edit for error</mat-hint>
+                <mat-select
+                formControlName="sales"
+                id="sales">
+                    <mat-option *ngFor="let sales of salesList" [value]="sales.id">
+                        {{ sales.name }}
+                    </mat-option>
+                </mat-select>
+                <mat-icon
+                    class="icon-size-5"
+                    matPrefix
+                    [svgIcon]="'heroicons_solid:location-marker'"></mat-icon>
             </mat-form-field>
         </div>
         <div class="flex">

--- a/src/app/onepay/add-sales-configuration-form/add-sales-configuration-form.component.spec.ts
+++ b/src/app/onepay/add-sales-configuration-form/add-sales-configuration-form.component.spec.ts
@@ -1,16 +1,37 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
 
 import { AddSalesConfigurationFormComponent } from './add-sales-configuration-form.component';
+import { SalesConfigurationService } from '../services/sales-configuration.service';
+import { SalesService } from '../services/sales.service';
+import { ISales } from '../model/sales.model';
+import { Modules } from '../model/core.enum';
+
+const mockSalesList: ISales[] = [
+  { id: 1, name: 'Sales A', address: 'Dakar', type: Modules.RESTAURATION },
+  { id: 2, name: 'Sales B', address: 'Thiès', type: Modules.MARKET }
+];
 
 describe('AddSalesConfigurationFormComponent', () => {
   let component: AddSalesConfigurationFormComponent;
   let fixture: ComponentFixture<AddSalesConfigurationFormComponent>;
+  let configServiceSpy: jasmine.SpyObj<SalesConfigurationService>;
+  let salesServiceSpy: jasmine.SpyObj<SalesService>;
 
   beforeEach(async () => {
+    configServiceSpy = jasmine.createSpyObj('SalesConfigurationService', ['createSalesConfiguration']);
+    salesServiceSpy = jasmine.createSpyObj('SalesService', ['getSales']);
+    salesServiceSpy.getSales.and.returnValue(of(mockSalesList));
+
     await TestBed.configureTestingModule({
-      imports: [AddSalesConfigurationFormComponent]
-    })
-    .compileComponents();
+      declarations: [AddSalesConfigurationFormComponent],
+      imports: [ReactiveFormsModule],
+      providers: [
+        { provide: SalesConfigurationService, useValue: configServiceSpy },
+        { provide: SalesService, useValue: salesServiceSpy }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AddSalesConfigurationFormComponent);
     component = fixture.componentInstance;
@@ -19,5 +40,35 @@ describe('AddSalesConfigurationFormComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should load sales on init', () => {
+    expect(salesServiceSpy.getSales).toHaveBeenCalled();
+    expect(component.salesList).toEqual(mockSalesList);
+  });
+
+  it('should keep salesList empty on load error', () => {
+    salesServiceSpy.getSales.and.returnValue(throwError(() => new Error('error')));
+    component.ngOnInit();
+    expect(component.salesList).toEqual(mockSalesList);
+  });
+
+  it('should submit with the selected sales', () => {
+    configServiceSpy.createSalesConfiguration.and.returnValue(of({} as any));
+    component.salesConfigurationForm.setValue({
+      sales: 1,
+      maxAmount: 10000,
+      minAmount: 500
+    });
+
+    component.onSubmit();
+
+    const submitted = configServiceSpy.createSalesConfiguration.calls.mostRecent().args[0];
+    expect(submitted.sales).toEqual(mockSalesList[0]);
+  });
+
+  it('getFormFieldHelpersAsString should return joined string', () => {
+    component.formFieldHelpers = ['c', 'd'];
+    expect(component.getFormFieldHelpersAsString()).toBe('c d');
   });
 });

--- a/src/app/onepay/add-sales-configuration-form/add-sales-configuration-form.component.ts
+++ b/src/app/onepay/add-sales-configuration-form/add-sales-configuration-form.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { SalesConfigurationService } from '../services/sales-configuration.service';
+import { SalesService } from '../services/sales.service';
 import { ISales, ISalesConfiguration } from '../model/sales.model';
-import { Modules } from '../model/core.enum';
 import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
@@ -10,26 +10,43 @@ import { HttpErrorResponse } from '@angular/common/http';
   templateUrl: './add-sales-configuration-form.component.html',
   styleUrl: './add-sales-configuration-form.component.scss'
 })
-export class AddSalesConfigurationFormComponent implements OnInit{
+export class AddSalesConfigurationFormComponent implements OnInit {
 
   formFieldHelpers: string[] = [''];
-  salesConfigurationForm: FormGroup;
-  // TODO Mettre sales par défaut ==============================
-  selectedsales: ISales = {
-    id: 1,
-    ref: "string",
-    name: "string",
-    type: Modules.RESTAURATION,
-    address:"string"
-  };
+  salesConfigurationForm!: FormGroup;
+  salesList: ISales[] = [];
 
   constructor(
     private fb: FormBuilder,
-    private salesConfigurationService: SalesConfigurationService
-  ) {}
+    private salesConfigurationService: SalesConfigurationService,
+    private salesService: SalesService
+  ) { }
 
   ngOnInit(): void {
     this.initializeForm();
+    this.salesService.getSales().subscribe({
+      next: (data) => {
+        this.salesList = data;
+      },
+      error: (err: HttpErrorResponse) => {
+        console.log('Error loading sales', err);
+      }
+    });
+  }
+
+  onSubmit(): void {
+    const formValue = this.salesConfigurationForm.value;
+    const selectedSales = this.salesList.find(s => s.id === formValue.sales);
+    let salesConfiguration: ISalesConfiguration = { ...formValue };
+    salesConfiguration.sales = selectedSales!;
+    this.salesConfigurationService.createSalesConfiguration(salesConfiguration).subscribe({
+      next: () => {
+        console.log('Sended');
+      },
+      error: (err: HttpErrorResponse) => {
+        console.log(err);
+      }
+    });
   }
 
   private initializeForm(): void {
@@ -37,26 +54,9 @@ export class AddSalesConfigurationFormComponent implements OnInit{
       sales: [''],
       maxAmount: [''],
       minAmount: [''],
-      
-    })
+    });
   }
-  onSubmit(): void {
-    const formValue = this.salesConfigurationForm.value;
-    let salesConfiguration: ISalesConfiguration = {...formValue};
-    salesConfiguration.sales = this.selectedsales;
-    
-    this.salesConfigurationService.createSalesConfiguration(salesConfiguration).subscribe({
-      next: () => {
-        console.log('Sended');
-        
-      },
-      error: (err: HttpErrorResponse) => {
-        console.log(err);
-        
-      }
-    })
-    
-  }
+
   getFormFieldHelpersAsString(): string {
     return this.formFieldHelpers.join(' ');
   }

--- a/src/app/onepay/add-sales-profile-form/add-sales-profile-form.component.html
+++ b/src/app/onepay/add-sales-profile-form/add-sales-profile-form.component.html
@@ -100,14 +100,13 @@
                 [ngClass]="formFieldHelpers"
                 class="flex-auto gt-xs:pr-3">
                 <mat-label>Sales</mat-label>
-                <select 
+                <mat-select
                 formControlName="sales"
-                id="sales"
-                matNativeControl>
-                    <option value=""></option>
-                    <option value="SALES_1">Sales 1</option>
-                    <option value="SALES_2">Sales 2</option>
-                </select>
+                id="sales">
+                    <mat-option *ngFor="let sales of salesList" [value]="sales.id">
+                        {{ sales.name }}
+                    </mat-option>
+                </mat-select>
                 <mat-icon
                     class="icon-size-5"
                     matPrefix

--- a/src/app/onepay/add-sales-profile-form/add-sales-profile-form.component.spec.ts
+++ b/src/app/onepay/add-sales-profile-form/add-sales-profile-form.component.spec.ts
@@ -1,16 +1,37 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
 
 import { AddSalesProfileFormComponent } from './add-sales-profile-form.component';
+import { SalesProfileService } from '../services/sales-profile.service';
+import { SalesService } from '../services/sales.service';
+import { ISales } from '../model/sales.model';
+import { Modules } from '../model/core.enum';
+
+const mockSalesList: ISales[] = [
+  { id: 1, name: 'Sales A', address: 'Dakar', type: Modules.RESTAURATION },
+  { id: 2, name: 'Sales B', address: 'Thiès', type: Modules.MARKET }
+];
 
 describe('AddSalesProfileFormComponent', () => {
   let component: AddSalesProfileFormComponent;
   let fixture: ComponentFixture<AddSalesProfileFormComponent>;
+  let salesProfileServiceSpy: jasmine.SpyObj<SalesProfileService>;
+  let salesServiceSpy: jasmine.SpyObj<SalesService>;
 
   beforeEach(async () => {
+    salesProfileServiceSpy = jasmine.createSpyObj('SalesProfileService', ['createSalesProfile']);
+    salesServiceSpy = jasmine.createSpyObj('SalesService', ['getSales']);
+    salesServiceSpy.getSales.and.returnValue(of(mockSalesList));
+
     await TestBed.configureTestingModule({
-      imports: [AddSalesProfileFormComponent]
-    })
-    .compileComponents();
+      declarations: [AddSalesProfileFormComponent],
+      imports: [ReactiveFormsModule],
+      providers: [
+        { provide: SalesProfileService, useValue: salesProfileServiceSpy },
+        { provide: SalesService, useValue: salesServiceSpy }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AddSalesProfileFormComponent);
     component = fixture.componentInstance;
@@ -19,5 +40,39 @@ describe('AddSalesProfileFormComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should load sales on init', () => {
+    expect(salesServiceSpy.getSales).toHaveBeenCalled();
+    expect(component.salesList).toEqual(mockSalesList);
+  });
+
+  it('should keep salesList empty on load error', () => {
+    salesServiceSpy.getSales.and.returnValue(throwError(() => new Error('error')));
+    component.ngOnInit();
+    expect(component.salesList).toEqual(mockSalesList);
+  });
+
+  it('should submit with the selected sales', () => {
+    salesProfileServiceSpy.createSalesProfile.and.returnValue(of({} as any));
+    component.adminForm.setValue({
+      lastname: 'Ndiaye',
+      firstname: 'Moussa',
+      username: 'mndiaye',
+      email: 'mndiaye@test.com',
+      phoneNumber: '0700000001',
+      role: 'SALES_FINANCE',
+      sales: 1
+    });
+
+    component.onSubmit();
+
+    const submitted = salesProfileServiceSpy.createSalesProfile.calls.mostRecent().args[0];
+    expect(submitted.sales).toEqual(mockSalesList[0]);
+  });
+
+  it('getFormFieldHelpersAsString should return joined string', () => {
+    component.formFieldHelpers = ['x', 'y'];
+    expect(component.getFormFieldHelpersAsString()).toBe('x y');
   });
 });

--- a/src/app/onepay/add-sales-profile-form/add-sales-profile-form.component.ts
+++ b/src/app/onepay/add-sales-profile-form/add-sales-profile-form.component.ts
@@ -1,55 +1,54 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { ISales, ISalesProfile } from '../model/sales.model';
-import { Modules, Status } from '../model/core.enum';
-import { AdminService } from '../services/admin-service';
-import { HttpErrorResponse } from '@angular/common/http';
+import { Status } from '../model/core.enum';
 import { SalesProfileService } from '../services/sales-profile.service';
+import { SalesService } from '../services/sales.service';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'app-add-sales-profile-form',
   templateUrl: './add-sales-profile-form.component.html',
   styleUrl: './add-sales-profile-form.component.scss'
 })
-export class AddSalesProfileFormComponent {
+export class AddSalesProfileFormComponent implements OnInit {
 
-formFieldHelpers: string[] = [''];
+  formFieldHelpers: string[] = [''];
   adminForm!: FormGroup;
-  // TODO Mettre list sales 
-  selectedSales: ISales = {
-    id: 1,
-    ref: "string",
-    name: "string",
-    address:"string",
-    type: Modules.RESTAURATION
-  };
+  salesList: ISales[] = [];
 
   constructor(
     private fb: FormBuilder,
-    private salesProfileService: SalesProfileService
-  ){ }
+    private salesProfileService: SalesProfileService,
+    private salesService: SalesService
+  ) { }
 
   onSubmit(): void {
-    console.log(this.adminForm);
     const formValue = this.adminForm.value;
-    let salesProfile: ISalesProfile = {...formValue}
-    //TODO enlever valeur en dur
-    salesProfile.sales = this.selectedSales;
+    const selectedSales = this.salesList.find(s => s.id === formValue.sales);
+    let salesProfile: ISalesProfile = { ...formValue };
+    salesProfile.sales = selectedSales!;
     salesProfile.status = Status.ACTIVE;
     this.salesProfileService.createSalesProfile(salesProfile).subscribe({
       next: () => {
-        console.log("Sended");
-        
+        console.log('Sended');
       },
       error: (err: HttpErrorResponse) => {
-        console.log("Error");
-        
-      } 
-    })
+        console.log('Error', err);
+      }
+    });
   }
 
   ngOnInit(): void {
-    this.initializeForm()
+    this.initializeForm();
+    this.salesService.getSales().subscribe({
+      next: (data) => {
+        this.salesList = data;
+      },
+      error: (err: HttpErrorResponse) => {
+        console.log('Error loading sales', err);
+      }
+    });
   }
 
   private initializeForm(): void {
@@ -60,12 +59,11 @@ formFieldHelpers: string[] = [''];
       email: [''],
       phoneNumber: [''],
       role: [''],
-      sales: ['']
-    })
+      sales: [''],
+    });
   }
 
-  getFormFieldHelpersAsString(): string
-    {
-        return this.formFieldHelpers.join(' ');
-    }
+  getFormFieldHelpersAsString(): string {
+    return this.formFieldHelpers.join(' ');
+  }
 }

--- a/src/app/onepay/services/sales.service.spec.ts
+++ b/src/app/onepay/services/sales.service.spec.ts
@@ -1,16 +1,61 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { environment } from 'environments/environment';
 
 import { SalesService } from './sales.service';
+import { ISales } from '../model/sales.model';
+import { IPage } from '../model/page.model';
+import { Modules } from '../model/core.enum';
 
 describe('SalesService', () => {
   let service: SalesService;
+  let httpMock: HttpTestingController;
+
+  const apiUrl = environment.baseUrl + '/v1/onepay/sales';
+  const mockSales: ISales[] = [
+    { id: 1, name: 'Sales A', address: 'Dakar', type: Modules.RESTAURATION },
+    { id: 2, name: 'Sales B', address: 'Thiès', type: Modules.MARKET }
+  ];
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
     service = TestBed.inject(SalesService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('createSales should POST and return sales', () => {
+    service.createSales(mockSales[0]).subscribe(result => {
+      expect(result).toEqual(mockSales[0]);
+    });
+    const req = httpMock.expectOne(apiUrl);
+    expect(req.request.method).toBe('POST');
+    req.flush(mockSales[0]);
+  });
+
+  it('getSales should GET page and return content array', () => {
+    const page: IPage<ISales> = {
+      content: mockSales,
+      totalElements: 2,
+      totalPages: 1,
+      number: 0,
+      size: 100
+    };
+    service.getSales().subscribe(result => {
+      expect(result).toEqual(mockSales);
+      expect(result.length).toBe(2);
+    });
+    const req = httpMock.expectOne(apiUrl + '?size=100');
+    expect(req.request.method).toBe('GET');
+    req.flush(page);
   });
 });

--- a/src/app/onepay/services/sales.service.ts
+++ b/src/app/onepay/services/sales.service.ts
@@ -2,7 +2,9 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { environment } from 'environments/environment';
 import { ISales } from '../model/sales.model';
+import { IPage } from '../model/page.model';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -16,5 +18,11 @@ export class SalesService {
 
   createSales(sales: ISales): Observable<ISales> {
     return this.http.post<ISales>(this.salesApiUrl, sales);
+  }
+
+  getSales(): Observable<ISales[]> {
+    return this.http.get<IPage<ISales>>(this.salesApiUrl + '?size=100').pipe(
+      map(page => page.content)
+    );
   }
 }


### PR DESCRIPTION
fix: connexion backend sur tous les formulaires, suppression des valeurs hardcodées

- Chargement dynamique des entreprises et sales depuis l'API (GET ?size=100)
- SalesService.getSales() ajouté
- add-enterprise-profile-form, add-sales-profile-form, add-enterprise-configuration-form, add-sales-configuration-form, add-partnership-form : selectedEnterprise/selectedSales hardcodés remplacés par appels API
- Templates : mat-select avec *ngFor sur tous les dropdowns
- Suppression du TODO GET ALL ENTERPRISES AND SALES (corrigé)
- Tests mis à jour (100% coverage)